### PR TITLE
Drop unnecessary emitters during auth error

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,10 +85,8 @@ module.exports = async (config, onData) => {
                 }
             })
         } else if(authData.status == 'error') {
-            emmitter.emit('error', authData.error_reason);
             reject(new Error(authData.error_reason));
         } else {
-            emmitter.emit('error', 'Unable to make auth request');
             reject(new Error('Unable to make auth request'));
         }
     });


### PR DESCRIPTION
Do we really need to emit the error when the promise is already being rejected? In testing, I triggered a bad auth error, and the emitters actually threw another error so the rejection was actually never hit gracefully. This change seems to make errors flow through more smoothly.